### PR TITLE
Enabling django_query_profiler without detailed view on a randomly downloaded project

### DIFF
--- a/coffee_master/settings.py
+++ b/coffee_master/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 """
 
 import os
+from django_query_profiler.settings import *
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -20,7 +21,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/
 
 # Production mode
-PRODUCTION = True
+PRODUCTION = False
 
 # SECURITY WARNING: keep the secret key used in production secret!
 if PRODUCTION:
@@ -54,6 +55,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'django_query_profiler.client.middleware.QueryProfilerMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -89,7 +91,7 @@ WSGI_APPLICATION = 'coffee_master.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
+        'ENGINE': 'django_query_profiler.django.db.backends.sqlite3',
         'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
     }
 }


### PR DESCRIPTION
This is how the chrome plugin looks like:

**Summary view**

<img width="1680" alt="chrome plugin screenshot" src="https://user-images.githubusercontent.com/57979360/71563245-10b8aa80-2a41-11ea-8303-963311043a57.png">
